### PR TITLE
updated jackson-databind to a version 2.9.5 and uplifted parent version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+- Version upgrade.
+- Jackson.databind.version updated to 2.9.5
+
 ## 0.0.5
 - Verson alignments.
 - google-gson.version to 2.8.1 and logback.version to 1.1.9

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.Ericsson</groupId>
     <artifactId>eiffel-remrem-parent</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
     <packaging>pom</packaging>
     <properties>
         <slf4j.version>1.7.25</slf4j.version>
@@ -23,7 +23,7 @@
         <commans.lang3.version>3.7</commans.lang3.version>
         <commons.io.version>2.6</commons.io.version>
         <mockito.version>2.8.47</mockito.version>
-        <jackson.databind.version>2.9.4</jackson.databind.version>
+        <jackson.databind.version>2.9.5</jackson.databind.version>
         <json.schema.validator.version>2.2.6</json.schema.validator.version>
         <gson.version>2.8.1</gson.version>
         <swagger.ui.version>2.6.1</swagger.ui.version>


### PR DESCRIPTION
resolved #7 [https://github.com/eiffel-community/eiffel-remrem-parent/issues/7]


