### PR TITLE
Eiffel 2.0 components 3PP Version Uplift.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.7
+- Version upgrade.
+- json-schema-validator updated to 2.2.8
+
 ## 0.0.6
 - Version upgrade.
 - Jackson.databind.version updated to 2.9.5

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.Ericsson</groupId>
     <artifactId>eiffel-remrem-parent</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7</version>
     <packaging>pom</packaging>
     <properties>
         <slf4j.version>1.7.25</slf4j.version>
@@ -24,7 +24,7 @@
         <commons.io.version>2.6</commons.io.version>
         <mockito.version>2.8.47</mockito.version>
         <jackson.databind.version>2.9.5</jackson.databind.version>
-        <json.schema.validator.version>2.2.6</json.schema.validator.version>
+        <json.schema.validator.version>2.2.8</json.schema.validator.version>
         <gson.version>2.8.1</gson.version>
         <swagger.ui.version>2.6.1</swagger.ui.version>
         <powermock.version>1.7.3</powermock.version>


### PR DESCRIPTION
Upgraded Json schema validator to 2.2.8 in remrem-parent.


